### PR TITLE
Replace spread operator with eval() to allow safe transpilation to ES5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# cocoascript-class
+# cocoascript-class-babel-safe
+
+**This is a (hopefully temporary) fork of `cocoascript-class` that can be safely transpiled to ES5.**
+
 Lets you create real ObjC classes in cocoascript so you can implement delegates, subclass builtin types, etc
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -1,17 +1,19 @@
 {
-  "name": "cocoascript-class",
+  "name": "cocoascript-class-babel-safe",
   "version": "0.1.0",
-  "description": "Lets you create real ObjC classes in cocoascript so you can implement delegates, subclass builtin types, etc",
+  "description": "A fork of cocoascript-class that can be safely transpiled to ES5",
   "main": "lib/index.js",
-  "repository": "https://github.com/darknoon/cocoascript-class",
+  "repository": "https://github.com/atlassian/cocoascript-class",
   "author": "Andrew Pouliot <andrew@darknoon.com>",
+  "contributors": [
+    "Tim Pettersen <tim@atlassian.com>"
+  ],
   "scripts": {
     "build": "babel src -d lib"
   },
   "license": "MIT",
   "devDependencies": {
-    "babel": "^6.23.0",
-    "babel-cli": "^6.24.0",
+    "babel-cli": "^6.26.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.24.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cocoascript-class-babel-safe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A fork of cocoascript-class that can be safely transpiled to ES5",
   "main": "lib/index.js",
   "repository": "https://github.com/atlassian/cocoascript-class",

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,10 +1,13 @@
 // You can store this to call your function. this must be bound to the current instance.
 export function SuperCall(selector, argTypes, returnType) {
   const func = CFunc("objc_msgSendSuper", [{type: '^' + objc_super_typeEncoding}, {type: ":"}, ...argTypes], returnType);
-  return function(...args) {
+  return function() {
     const struct = make_objc_super(this, this.superclass());
     const structPtr = MOPointer.alloc().initWithValue_(struct);
-    return func(structPtr, selector, ...args);
+    const params = ['structPtr', 'selector'].concat(
+      [].slice.apply(arguments).map((val, i) => `arguments[${i}]`)
+    )
+    return eval(`func(${params.join(', ')})`)
   };
 }
 


### PR DESCRIPTION
Addresses the issue discussed in #1 & https://github.com/airbnb/react-sketchapp/issues/106#issuecomment-327771451

Thanks for the awesome library btw!