### PR TITLE
Replace spread operator with eval() to allow safe transpilation to ES5

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,10 +1,13 @@
 // You can store this to call your function. this must be bound to the current instance.
 export function SuperCall(selector, argTypes, returnType) {
   const func = CFunc("objc_msgSendSuper", [{type: '^' + objc_super_typeEncoding}, {type: ":"}, ...argTypes], returnType);
-  return function(...args) {
+  return function() {
     const struct = make_objc_super(this, this.superclass());
     const structPtr = MOPointer.alloc().initWithValue_(struct);
-    return func(structPtr, selector, ...args);
+    const params = ['structPtr', 'selector'].concat(
+      [].slice.apply(arguments).map((val, i) => `arguments[${i}]`)
+    )
+    return eval(`func(${params.join(', ')})`)
   };
 }
 


### PR DESCRIPTION
Addresses the issue discussed in #1 & airbnb/react-sketchapp#106 (comment)

Thanks for the awesome library btw!