### PR TITLE
Adds class method support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,40 @@ const obj = HasDescriptionClass.new();
 log(obj); // calls description to become a string
 ````
 
+### Setting your superclass
 
+The `superclass` property lets you set your superclass, equivalent to `@interface myClass : superclass`. Here, we subclass `NSView` and create a square view:
+
+````js
+import ObjCClass from 'cocoascript-class'
+
+const ViewClass = new ObjCClass({
+  superclass: NSView
+});
+
+const view = ViewClass.new();
+// call inherited methods
+view.setFrame(NSMakeRect(0, 0, 100, 100));
+````
+
+If not set, the superclass is `NSObject`.
+
+### Adding class methods
+
+The `classMethods` property lets you add class methods similar to how instance methods are added. Here is an example:
+
+````js
+import ObjCClass from 'cocoascript-class'
+
+const HasClassMethodsClass = new ObjCClass({
+  classMethods: {
+    test() {
+      log("test");
+    }
+  }
+});
+
+// call methods on the class
+[HasClassMethodsClass test];
+HasClassMethodsClass.test();
+````

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cocoascript-class",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Lets you create real ObjC classes in cocoascript so you can implement delegates, subclass builtin types, etc",
   "main": "lib/index.js",
   "repository": "https://github.com/darknoon/cocoascript-class",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ const SuperInit = SuperCall(NSStringFromSelector("init"), [], {type:"@"});
 export default function ObjCClass(defn) {
   const superclass = defn.superclass || NSObject;
   const className = (defn.className || defn.classname || "ObjCClass") + NSUUID.UUID().UUIDString()
-  const reserved = new Set(['className', 'classname','superclass']);
+  const classMethods = (defn.classMethods || defn.classmethods || {})
+  const reserved = new Set(['className', 'classname','superclass', 'classMethods', 'classmethods']);
   var cls = MOClassDescription.allocateDescriptionForClassWithName_superclass_(className, superclass)
   // Add each handler to the class description
   const ivars = [];
@@ -23,6 +24,14 @@ export default function ObjCClass(defn) {
     } else if (!reserved.has(key)) {
        ivars.push(key);
        cls.addInstanceVariableWithName_typeEncoding(key, "@");
+    }
+  }
+  // Add each class method to the class description
+  for(var key in classMethods) {
+    const v = classMethods[key]
+    if (typeof v == 'function') {
+      var selector = NSSelectorFromString(key)
+      cls.addClassMethodWithSelector_function_(selector, v);
     }
   }
 
@@ -48,4 +57,3 @@ function getIvar(obj, name) {
   object_getInstanceVariable(obj, name, retPtr);
   return retPtr.value().retain().autorelease();
 }
-


### PR DESCRIPTION
@darknoon Working with class methods recently so thought it'd be helpful to suggest the changes upstream. This reserves 2 properties, principally `classMethods`, accepting an object of methods to add as class methods similar to how instance methods are added at object root. Thoughts?